### PR TITLE
Move to haskell-party org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Feed
 
 [![feed](https://img.shields.io/hackage/v/feed.svg)](http://hackage.haskell.org/package/feed)
-[![Build Status](https://travis-ci.org/bergmark/feed.svg?branch=master)](https://travis-ci.org/bergmark/feed)
+![Build Status](https://github.com/haskell-party/feed/actions/workflows/haskell-ci.yml/badge.svg)
+
 
 ## Goal
 
@@ -194,7 +195,7 @@ feed =
 -- </feed>
 ```
 
-See [here](https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom.hs) for this content as an uninterrupted running example.
+See [here](https://github.com/haskell-party/feed/blob/master/tests/Example/CreateAtom.hs) for this content as an uninterrupted running example.
 
 ```haskell
 -- Dummy main needed to compile this file with markdown-unlit

--- a/feed.cabal
+++ b/feed.cabal
@@ -13,14 +13,14 @@ description:         Interfacing with RSS (v 0.9x, 2.x, 1.0) + Atom feeds.
                      of feeds in Haskell.
                      .
                      See here for an example of how to create an Atom feed:
-                     <https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom.hs>
+                     <https://github.com/haskell-party/feed/blob/master/tests/Example/CreateAtom.hs>
                      .
                      For basic reading and editing of feeds, consult
                      the documentation of the Text.Feed.* hierarchy.
 author:              Sigbjorn Finne <sof@forkIO.com>
 maintainer:          Adam Bergmark <adam@bergmark.nl>
-homepage:            https://github.com/bergmark/feed
-bug-reports:         https://github.com/bergmark/feed/issues
+homepage:            https://github.com/haskell-party/feed
+bug-reports:         https://github.com/haskell-party/feed/issues
 cabal-version:       2.0
 build-type:          Simple
 tested-with:
@@ -43,7 +43,7 @@ extra-source-files:
 
 source-repository head
   type:              git
-  location:          https://github.com/bergmark/feed.git
+  location:          https://github.com/haskell-party/feed.git
 
 library
   ghc-options:       -Wall


### PR DESCRIPTION
I created a new organization to store some of my haskell repos. This allows us to have more owners that can manage the project (user permissions, in particular) in case I'm unavailable.
