### PR TITLE
Allow text 2.0

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -85,7 +85,7 @@ library
     , old-locale == 1.0.*
     , old-time >= 1 && < 1.2
     , safe == 0.3.*
-    , text < 1.3
+    , text < 1.3 || ==2.0.*
     , time < 1.12
     , time-locale-compat == 0.1.*
     , utf8-string < 1.1
@@ -125,7 +125,7 @@ test-suite tests
     , syb
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*
-    , text < 1.3
+    , text < 1.3 || ==2.0.*
     , time < 1.12
     , xml-types >= 0.3.6 && < 0.4
     , xml-conduit >= 1.3 && < 1.10


### PR DESCRIPTION
`cabal build --enable-tests --constrain 'text == 2.0'` passes, `cabal test --enable-tests --constrain 'text == 2.0'` fails the readme doctest:

```
Test suite readme-doctests: RUNNING...
readme-doctests: <command line>: cannot satisfy -package xml-types
    (use -v for more information)

Test suite readme-doctests: FAIL
```

I get the same error on the master branch though, so it's probably caused by my setup rather than these changes. Anyway, I hope CI will double-check it for me.