### PR TITLE
Allow text 2.1

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -86,7 +86,7 @@ library
     , old-locale == 1.0.*
     , old-time >= 1 && < 1.2
     , safe == 0.3.*
-    , text < 1.3 || ==2.0.*
+    , text < 1.3 || >= 2.0 && < 2.2
     , time < 1.13
     , time-locale-compat == 0.1.*
     , utf8-string < 1.1
@@ -126,7 +126,7 @@ test-suite tests
     , syb
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*
-    , text < 1.3 || ==2.0.*
+    , text < 1.3 || >= 2.0 && < 2.2
     , time < 1.13
     , xml-types >= 0.3.6 && < 0.4
     , xml-conduit >= 1.3 && < 1.10


### PR DESCRIPTION
Verified with `for action in build test ; do cabal $action --enable-tests --constrain 'text == 2.1' || break ; done` and GHC 9.4.8. Doctests didn't run because I don't have xml-types installed system-wide (I guess).

This should help with https://github.com/commercialhaskell/stackage/issues/7222 and also allow me to update hakyll-convert, which depends on feed.