### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -80,13 +80,13 @@ library
     Data.Text.Util
     Data.XML.Compat
   build-depends:
-      base >= 4 && < 4.18
-    , base-compat >= 0.9 && < 0.13
-    , bytestring >= 0.9 && < 0.12
+      base >= 4 && < 4.20
+    , base-compat >= 0.9 && < 0.14
+    , bytestring >= 0.9 && < 0.13
     , old-locale == 1.0.*
     , old-time >= 1 && < 1.2
     , safe == 0.3.*
-    , text < 1.3 || ==2.0.*
+    , text < 1.3 || ^>=2.0 || ^>=2.1
     , time < 1.13
     , time-locale-compat == 0.1.*
     , utf8-string < 1.1
@@ -118,15 +118,15 @@ test-suite tests
     Text.RSS.Tests
     Text.RSS.Utils
   build-depends:
-      base >= 4.6 && < 4.18
-    , base-compat >= 0.9 && < 0.13
+      base >= 4.6 && < 4.20
+    , base-compat >= 0.9 && < 0.14
     , HUnit >= 1.2 && < 1.7
     , feed
     , old-time >= 1 && < 1.2
     , syb
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*
-    , text < 1.3 || ==2.0.*
+    , text < 1.3 || ^>=2.0 || ^>=2.1
     , time < 1.13
     , xml-types >= 0.3.6 && < 0.4
     , xml-conduit >= 1.3 && < 1.10
@@ -141,7 +141,7 @@ test-suite readme
   type:              exitcode-stdio-1.0
   build-depends:
       base >= 4.6
-    , base-compat >= 0.9 && < 0.13
+    , base-compat >= 0.9 && < 0.14
     , text
     , feed
     , xml-conduit


### PR DESCRIPTION
I was not able to get the tests to build. Something to do with `doctests` which I am unfamiliar with.

Would also really appreciate a Hackage metadata edit.